### PR TITLE
Ensure swap back

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,3 @@
+source "https://rubygems.org"
+
+gemspec

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,34 @@
+PATH
+  remote: .
+  specs:
+    resque-swapper (0.1.1)
+      resque (>= 1.15.0)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    multi_json (1.3.6)
+    rack (1.4.1)
+    rack-protection (1.2.0)
+      rack
+    redis (2.2.2)
+    redis-namespace (1.0.3)
+      redis (< 3.0.0)
+    resque (1.20.0)
+      multi_json (~> 1.0)
+      redis-namespace (~> 1.0.2)
+      sinatra (>= 0.9.2)
+      vegas (~> 0.1.2)
+    sinatra (1.3.2)
+      rack (~> 1.3, >= 1.3.6)
+      rack-protection (~> 1.2)
+      tilt (~> 1.3, >= 1.3.3)
+    tilt (1.3.3)
+    vegas (0.1.11)
+      rack (>= 1.0.0)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  resque-swapper!

--- a/lib/resque-swapper/resque-swapper.rb
+++ b/lib/resque-swapper/resque-swapper.rb
@@ -27,8 +27,11 @@ module Resque
     # Create Redis connection.
     Resque.redis = server_connect(server, Swapper.config(server))
     if block_given?
-      yield Resque
-      Resque.redis = current
+      begin
+        yield Resque
+      ensure
+        Resque.redis = current
+      end
     end
     Resque
   end

--- a/tests/config/resque.yml
+++ b/tests/config/resque.yml
@@ -2,11 +2,14 @@ test:
   localhost:
     host: 'localhost'
     port: 6379
+    db: 0
 
   merlin:
     host: 'localhost'
-    port: 6380
+    port: 6379
+    db: 1
     
   aang:
     host: 'localhost'
-    port: 6381
+    port: 6379
+    db: 2

--- a/tests/swapper_test.rb
+++ b/tests/swapper_test.rb
@@ -37,6 +37,18 @@ class ResqueSwapperTest < Test::Unit::TestCase
     assert_equal nil, Resque.redis.get('value')
   end
 
+  def test_swap_with_exception
+    current = Resque.redis
+    
+    assert_raise(RuntimeError, "EGADS!") do
+      Resque.swap(:merlin) do |resque|
+        raise "EGADS!"
+      end
+    end
+
+    assert_same_db Resque.redis, current, "Should swap back to starting db on exception"
+  end
+
   def assert_same_db(redis1, redis2, msg)
     assert_equal redis1.client.db, redis2.client.db, msg
   end

--- a/tests/swapper_test.rb
+++ b/tests/swapper_test.rb
@@ -21,19 +21,24 @@ class ResqueSwapperTest < Test::Unit::TestCase
     Resque.swap(:merlin) do |resque|
       resque.redis.set('value', "I am Merlin!")
     end
-    assert_equal Resque.redis.id, current.id, "Current shound't be swapped after swap with block."
+    assert_same_db Resque.redis, current, "Current shound't be swapped after swap with block."
     
     Resque.swap(:aang) do |resque|
       resque.redis.set('value', "I am Aang!")
     end
-    assert_equal Resque.redis.id, current.id, "Current shound't be swapped after swap with block."
+    assert_same_db Resque.redis, current, "Current shound't be swapped after swap with block."
     
     Resque.swap(:aang)
-    assert_equal Resque.redis.id, Resque.server(:aang).id, "Current Redis should be swapped after direct swap."
+     
+    assert_same_db Resque.redis, Resque.server(:aang), "Current Redis should be swapped after direct swap."
     
     Resque.swap(:localhost)
     
     assert_equal nil, Resque.redis.get('value')
+  end
+
+  def assert_same_db(redis1, redis2, msg)
+    assert_equal redis1.client.db, redis2.client.db, msg
   end
 end
 


### PR DESCRIPTION
If there is an exception in the middle of a swap block, swapper should swap back to the original and continue to raise the error. The old behavior would stay in the new database. If you swapped within a job in resque, this would cause job failures to get posted to a different redis server than from where they originated.
