### PR TITLE
Move VERSION to namespaced file.

### DIFF
--- a/lib/resque-swapper/version.rb
+++ b/lib/resque-swapper/version.rb
@@ -1,0 +1,5 @@
+module Resque
+  module Swapper
+    VERSION = '0.1.1'
+  end
+end

--- a/resque-swapper.gemspec
+++ b/resque-swapper.gemspec
@@ -1,8 +1,11 @@
-VERSION = '0.1.1'
+require File.join(File.dirname(__FILE__),
+                  'lib',
+                  'resque-swapper',
+                  'version')
 
 Gem::Specification.new do |s|
   s.name = 'resque-swapper'
-  s.version = VERSION
+  s.version = Resque::Swapper::VERSION
   s.summary = 'Swapping tool for Resque server on runtime.'
   s.homepage = "http://github.com/endel/resque-swapper"
   


### PR DESCRIPTION
Defining VERSION in the gemspec can cause issues in larger projects.
Evidently, ruby defines its version in the root VERSION constant (i.e.
"1.9.3"), and libraries which check this would see 0.1.1. e2mm would
actually abort the program as a result, thinking that ruby's version was
0.1.1

I think this might only manifest if you point your Gemfile at your github repo rather than getting the released gem, but that could just be dumb luck. I recommend that if you accept this, that you bump the version and release a new gem to be on the safe side.
